### PR TITLE
Rename change method caller to transact

### DIFF
--- a/lib/contract.d.ts
+++ b/lib/contract.d.ts
@@ -25,7 +25,7 @@ export declare class ContractMethodInvocation {
     get contract(): Contract;
     get arguments(): any[];
     get method(): AbiFunction;
-    call?(wallet: Wallet, opts?: FunctionCallOptions): Promise<void | FinalExecutionOutcome>;
+    transact?(wallet: Wallet, opts?: FunctionCallOptions): Promise<void | FinalExecutionOutcome>;
     view?(): Promise<any>;
     /**
      * @param contract NEAR Contract object

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.testingExports = exports.Contract = exports.ContractMethods = exports.ContractMethodInvocation = exports.AbiValidationError = void 0;
-async function callInternal(account, contractId, methodName, args, opts) {
+async function transactInternal(account, contractId, methodName, args, opts) {
     return await account.signAndSendTransaction({
         signerId: opts?.signer,
         receiverId: contractId,
@@ -127,14 +127,14 @@ class ContractMethodInvocation {
             });
         }
         else {
-            this.call = async (account, opts) => {
+            this.transact = async (account, opts) => {
                 // Using inner NAJ APIs for result for consistency, but this might
                 // not be ideal API.
-                return callInternal(account, contract.contractId, fn.name, serializeArgs(fn.name, args, fn.params), opts);
+                return transactInternal(account, contract.contractId, fn.name, serializeArgs(fn.name, args, fn.params), opts);
             };
-            Object.defineProperty(this.call, 'name', {
+            Object.defineProperty(this.transact, 'name', {
                 writable: false,
-                value: `ContractMethod[${fn.name}].call`,
+                value: `ContractMethod[${fn.name}].transact`,
             });
         }
     }

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -18,7 +18,7 @@ export interface FunctionCallOptions {
     walletCallbackUrl?: string;
 }
 
-async function callInternal(
+async function transactInternal(
     account: Wallet,
     contractId: string,
     methodName: string,
@@ -163,7 +163,7 @@ export class ContractMethodInvocation {
         return this.#method;
     }
 
-    call?(
+    transact?(
         wallet: Wallet,
         opts?: FunctionCallOptions
     ): Promise<void | FinalExecutionOutcome>;
@@ -193,13 +193,13 @@ export class ContractMethodInvocation {
                 value: `ContractMethod[${fn.name}].view`,
             });
         } else {
-            this.call = async (
+            this.transact = async (
                 account,
                 opts
             ): Promise<void | FinalExecutionOutcome> => {
                 // Using inner NAJ APIs for result for consistency, but this might
                 // not be ideal API.
-                return callInternal(
+                return transactInternal(
                     account,
                     contract.contractId,
                     fn.name,
@@ -207,9 +207,9 @@ export class ContractMethodInvocation {
                     opts
                 );
             };
-            Object.defineProperty(this.call, 'name', {
+            Object.defineProperty(this.transact, 'name', {
                 writable: false,
-                value: `ContractMethod[${fn.name}].call`,
+                value: `ContractMethod[${fn.name}].transact`,
             });
         }
     }


### PR DESCRIPTION
Synced with @itegulov, and we agree `.transact()` is a better name here, matching it's [counterpart](https://docs.rs/near-workspaces/0.5.0/near_workspaces/operations/struct.CallTransaction.html#method.transact) in [`workspaces-rs`](https://github.com/near/workspaces-rs).